### PR TITLE
fix: Align case item cards vertically, stretch

### DIFF
--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -66,7 +66,7 @@ const PostCard = ({
   ...rest
 }) => (
   <Card
-    className={horizontal ? "d-flex flex-column flex-md-row" : ""}
+    className={horizontal ? "d-flex flex-column flex-md-row" : "h-100"}
     {...rest}
   >
     {horizontal ? (
@@ -85,7 +85,7 @@ const PostCard = ({
     ) : (
       <Box className="position-relative">
         <Link href={link}>
-          <a className="w-100 h-100 d-flex">
+          <a className="w-100">
             <img src={img} alt="" className="w-100 img-fluid" />
             {imgBrand && (
               <BrandImage>

--- a/src/sections/case/CaseList1.js
+++ b/src/sections/case/CaseList1.js
@@ -17,8 +17,8 @@ const CaseList = () => (
     {/* <!-- Feature section --> */}
     <Section className="position-relative">
       <Container>
-        <Row className="align-items-center justify-content-center">
-          <Col lg="4" className="mb-5 mb-lg-0">
+        <Row className="justify-content-center">
+          <Col lg="4" className="mb-5 mb-lg-0 flex-grow-1">
             <PostCard
               img={tjejjourenThumbnail}
               title="Tjejjouren Väst"
@@ -27,7 +27,7 @@ const CaseList = () => (
               Appen Stella ger tjejer stöd dygnet runt
             </PostCard>
           </Col>
-          <Col lg="4" className="mb-5 mb-lg-0">
+          <Col lg="4" className="mb-5 mb-lg-0 flex-grow-1">
             <PostCard
               img={imgCase1}
               imgBrand={imgBrand1}
@@ -38,7 +38,7 @@ const CaseList = () => (
               andrahandsuthyrning
             </PostCard>
           </Col>
-          <Col lg="4" className="mb-5 mb-lg-0">
+          <Col lg="4" className="mb-5 mb-lg-0 flex-grow-1">
             <PostCard
               img={imgCase3}
               imgBrand={imgBrand3}


### PR DESCRIPTION
https://trello.com/c/jb1yg7oR/9-fixa-cases-i-safari

<img width="1215" alt="Screenshot 2021-05-07 at 13 45 38" src="https://user-images.githubusercontent.com/646665/117445042-85a3ca80-af3a-11eb-8b7c-63d1088d7d4f.png">

Nästa steg vore att fixa bilder med samma dimensioner så att det blir unisont och fint. Jag tror(?) att det är såhär det är tänkt från början, men det är väl lite av en gissning
