### PR TITLE
fix(a11y): disable animate on scroll with prefers-reduced-motion

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -41,7 +41,9 @@ const Layout = ({ children, pageContext }) => {
   const [visibleLoader, setVisibleLoader] = useState(true);
 
   useLayoutEffect(() => {
-    AOS.init();
+    AOS.init({
+      disable: window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+    });
     setVisibleLoader(false);
   }, []);
 


### PR DESCRIPTION
This PR disables the animations on scroll (the `aos` library) when the user has the CSS setting [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) enabled. `window.matchMedia` is [supported in all browsers](https://caniuse.com/matchmedia) so there should be no issues with using it.

Test the functionality by emulating `prefers-reduced-motion` using the browser console and reloading the page (`aos` is initialized only on page load).

<img width="335" alt="Skärmavbild 2021-06-11 kl  06 59 18" src="https://user-images.githubusercontent.com/1478102/121633156-920fcb80-ca82-11eb-9254-800225819fe2.png">