### PR TITLE
fix: sort by fullname and slice array before sorting

### DIFF
--- a/src/sections/about/Team.js
+++ b/src/sections/about/Team.js
@@ -84,7 +84,8 @@ const Team = () => (
         </Row>
         <Row className="justify-content-center">
           {team
-            .sort((a, b) => a.fullname > b.fullname)
+            .slice()
+            .sort((a, b) => a.fullname.localeCompare(b.fullname))
             .map(({ fullname, title, email, phoneNumber, status }) => (
               <Col sm="6" md="5" lg="4" className="mt-3 mt-lg-4" key={email}>
                 <TeamCard


### PR DESCRIPTION
`.sort` is a [mutating array method](https://doesitmutate.xyz/sort/). Create a copy of the array using `.slice` and then run `.sort`. It might be related to the issues reported on [Twitter](https://twitter.com/a13xnet/status/1402999038987829265?s=21).

Using `localeCompare` over `>` yields better results with the sorting as can be seen in the before and after screenshots below.

| Before | After |
| ------ | ----- |
| <img width="908" alt="Skärmavbild 2021-06-11 kl  07 11 52" src="https://user-images.githubusercontent.com/1478102/121634125-57a72e00-ca84-11eb-8fe6-f6fd3fa67058.png"> | <img width="1122" alt="Skärmavbild 2021-06-11 kl  07 11 59" src="https://user-images.githubusercontent.com/1478102/121634132-5970f180-ca84-11eb-93bb-68e6dca39531.png"> | 