### PR TITLE
chore: add fading transitions on slider and make slider responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To make it clearer that the user is in preview mode we use the `ExitPreviewLink`
 
 If you want to add live preview to a document type you will need to add .views to deskStructure and then do the same as above.
 
-You might need to take a look in resolveProductionUrl aswell.
+You might need to take a look in resolveProductionUrl as well.
 
 ## Client
 

--- a/client/src/components/Carousel/Carousel.js
+++ b/client/src/components/Carousel/Carousel.js
@@ -42,10 +42,8 @@ const SliderStyled = styled(Slider)`
     &:before {
       content: '\f060';
     }
-    margin-left: -6px;
 
     @media ${device.lg} {
-      margin-left: 40px;
     }
   }
 
@@ -56,61 +54,122 @@ const SliderStyled = styled(Slider)`
     &:before {
       content: '\f061';
     }
-    margin-right: -6px;
-    @media ${device.lg} {
-      margin-right: 40px;
-    }
   }
 
   .slick-arrow:hover,
   .slick-arrow:focus {
     background: ${({ theme }) => theme.colors.light}!important;
     color: ${({ theme }) => theme.colors.secondary}!important;
+    box-shadow: ${({ theme }) =>
+      `0 1px 6px ${rgba(theme.colors.shadow, 0.125)}`};
     &:before {
       color: ${({ theme }) => theme.colors.secondary}!important;
     }
   }
+
+  .slick-track {
+    position: relative;
+    top: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .slick-list {
+    margin-bottom: 30px;
+    border-radius: 10px;
+    box-shadow: ${({ theme }) =>
+      `0 31px 25px ${rgba(theme.colors.shadow, 0.125)}`};
+    background: ${({ theme }) => theme.colors.light}!important;
+  }
+
+  .slick-slide {
+    opacity: 0;
+  }
+
+  .slick-active {
+    opacity: 1;
+    animation: fade-in 0.3s ease-in;
+  }
+  @keyframes fade-in {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  .slick-dots {
+    position: static;
+    margin-top: 30px;
+  }
+  .slick-dots li {
+    width: 45px;
+    height: 45px;
+  }
+  .slick-dots li button {
+    width: 45px;
+    height: 45px;
+    background: ${({ theme }) => theme.colors.secondary};
+    opacity: 1;
+    transition: 0.2s;
+    border-radius: 100%;
+    box-shadow: ${({ theme }) =>
+      `0 1px 6px ${rgba(theme.colors.shadow, 0.125)}`};
+  }
+  .slick-dots li button:hover,
+  .slick-dots li button:focus {
+    background: ${({ theme }) => theme.colors.light};
+  }
+  .slick-dots li.slick-active button {
+    background: ${({ theme }) => theme.colors.light};
+  }
+  .slick-dots li button::before {
+    display: none;
+  }
 `
 
 const SliderItem = styled(Box)`
-  padding: 30px;
+  padding: 30px 30px 60px;
   &:focus {
     outline: none;
+  }
+  @media ${device.md} {
+    padding: 30px 90px 60px;
   }
 `
 
 const SliderCard = styled(Box)`
-  border-radius: 10px;
   background: #fff;
   overflow: hidden;
-  box-shadow: ${({ theme }) =>
-    `0 52px 54px ${rgba(theme.colors.shadow, 0.125)}`};
   display: flex;
   flex-direction: column;
   align-items: center;
+
   @media ${device.sm} {
-    padding: 35px 35px 20px 35px;
+    padding: 35px 0;
   }
   @media ${device.md} {
     padding: 10px;
-    flex-direction: row;
   }
   @media ${device.lg} {
-    padding: 0 0 30px 30px;
-
-    margin: 60px 60px 100px 60px !important;
+    padding: 0 0 0 30px;
+    flex-direction: row;
+    // margin: 0 60px !important;
   }
 `
 
 const SliderImgContainer = styled(Box)`
   border-radius: 10px;
   overflow: hidden;
+  min-width: 100%;
 
   @media ${device.sm} {
-    min-width: 315px;
     padding: 0;
   }
-  @media ${device.md} {
+  @media ${device.lg} {
+    min-width: 315px;
   }
 
   img {
@@ -132,7 +191,10 @@ const SliderText = styled(Box)`
   align-items: left;
   justify-content: left;
   flex: auto;
-  padding: 80px 30px 0px;
+  padding: 60px 0 0 0;
+  @media ${device.lg} {
+    padding: 60px 30px;
+  }
 `
 
 const Coworker = ({ item }) => {
@@ -195,9 +257,18 @@ const Carousel = ({ content, coworker = false }) => {
     arrows: true,
     responsive: [
       {
-        breakpoint: breakpoints.lg,
+        breakpoint: breakpoints.md,
+        settings: {
+          dots: true,
+          infinite: true,
+          speed: 500,
+          slidesToShow: 1,
+          slidesToScroll: 1,
+          arrows: false,
+        },
       },
     ],
+    useCSS: false,
   }
 
   return (

--- a/client/src/components/Carousel/Carousel.js
+++ b/client/src/components/Carousel/Carousel.js
@@ -42,11 +42,7 @@ const SliderStyled = styled(Slider)`
     &:before {
       content: '\f060';
     }
-
-    @media ${device.lg} {
-    }
   }
-
   .slick-arrow.slick-next {
     right: 0;
     left: auto;
@@ -55,7 +51,6 @@ const SliderStyled = styled(Slider)`
       content: '\f061';
     }
   }
-
   .slick-arrow:hover,
   .slick-arrow:focus {
     background: ${({ theme }) => theme.colors.light}!important;
@@ -72,14 +67,18 @@ const SliderStyled = styled(Slider)`
     top: 0;
     left: 0;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+
+    @media ${device.md} {
+      align-items: center;
+    }
   }
 
   .slick-list {
     margin-bottom: 30px;
     border-radius: 10px;
     box-shadow: ${({ theme }) =>
-      `0 31px 25px ${rgba(theme.colors.shadow, 0.125)}`};
+      `0 10px 25px ${rgba(theme.colors.shadow, 0.125)}`};
     background: ${({ theme }) => theme.colors.light}!important;
   }
 
@@ -91,6 +90,7 @@ const SliderStyled = styled(Slider)`
     opacity: 1;
     animation: fade-in 0.3s ease-in;
   }
+
   @keyframes fade-in {
     0% {
       opacity: 0;
@@ -132,9 +132,11 @@ const SliderStyled = styled(Slider)`
 
 const SliderItem = styled(Box)`
   padding: 30px 30px 60px;
+
   &:focus {
     outline: none;
   }
+
   @media ${device.md} {
     padding: 30px 90px 60px;
   }
@@ -147,16 +149,17 @@ const SliderCard = styled(Box)`
   flex-direction: column;
   align-items: center;
 
-  @media ${device.sm} {
-    padding: 35px 0;
+  h4:first-of-type {
+    margin-top: 0;
   }
+
   @media ${device.md} {
     padding: 10px;
+    align-items: flex-start;
   }
   @media ${device.lg} {
     padding: 0 0 0 30px;
     flex-direction: row;
-    // margin: 0 60px !important;
   }
 `
 
@@ -165,13 +168,6 @@ const SliderImgContainer = styled(Box)`
   overflow: hidden;
   min-width: 100%;
 
-  @media ${device.sm} {
-    padding: 0;
-  }
-  @media ${device.lg} {
-    min-width: 315px;
-  }
-
   img {
     margin: 0 auto;
     max-width: unset;
@@ -179,8 +175,13 @@ const SliderImgContainer = styled(Box)`
   }
 
   @media ${device.sm} {
+    padding: 0;
     max-width: 100%;
     width: auto;
+  }
+  @media ${device.lg} {
+    min-width: 315px;
+    margin-top: 5px;
   }
 `
 
@@ -192,8 +193,13 @@ const SliderText = styled(Box)`
   justify-content: left;
   flex: auto;
   padding: 60px 0 0 0;
+
+  p {
+    margin-top: 0;
+  }
+
   @media ${device.lg} {
-    padding: 60px 30px;
+    padding: 0 0 0 30px;
   }
 `
 

--- a/client/src/sections/startpage/Testimonial.js
+++ b/client/src/sections/startpage/Testimonial.js
@@ -6,9 +6,9 @@ import Carousel from '../../components/Carousel'
 const Testimonial = ({ content }) => {
   return (
     <>
-      <Section bg="#F7F7FB" pb={['50px!important']}>
+      <Section bg="#F7F7FB" pb={['130px!important']}>
         <Container>
-          <Row className="justify-content-center mb-4">
+          <Row className="justify-content-center mb-5">
             <Col lg="9" md="9">
               <div className="text">
                 <Title>{content.title}</Title>


### PR DESCRIPTION
This PR does the following:
- Replaces the animation of the slider with transition. The only exception is when the user swipes, which combines animation and transition.
- Adds responsiveness to the slider, replacing arrow buttons with "dots" on mobile.

This is the first proposed change in animations on the site and the reason for it being its own PR is because the changes in css felt a bit too extensive/specific to combine with other adjustments to animations. Please let me know if this is the wrong way to go and I'll combine these changes with the coming ones.

ps. Seems like an unmerged and unrelated commit was included. The change in this was made while testing SSH connection with remote repo.