### PR TITLE
fix: calendar broke in 768px...991px viewport

### DIFF
--- a/client/src/components/HubspotForm/index.js
+++ b/client/src/components/HubspotForm/index.js
@@ -18,6 +18,7 @@ const FormStyled = styled.form`
 `
 const FrameStyled = styled.div`
   max-width: 484px;
+  margin: 0 auto;
 `
 
 const HubspotForm = ({

--- a/client/src/components/HubspotForm/index.js
+++ b/client/src/components/HubspotForm/index.js
@@ -16,6 +16,9 @@ const FormStyled = styled.form`
   width: 100%;
   text-align: center;
 `
+const FrameStyled = styled.div`
+  max-width: 484px;
+`
 
 const HubspotForm = ({
   value,
@@ -40,7 +43,7 @@ const HubspotForm = ({
         <Title>{title}</Title>
       </Box>
       <input type="hidden" name="form-name" value={value} />
-      <div
+      <FrameStyled
         className="meetings-iframe-container"
         data-src="https://meetings.hubspot.com/jonna-hjern/intromote-iteam?embed=true"
       />

--- a/client/src/pages/book.js
+++ b/client/src/pages/book.js
@@ -18,6 +18,9 @@ import ExitPreviewLink from '../components/ExitPreviewLink'
 import { NextSeo } from 'next-seo'
 
 const FormStyled = styled.form``
+const FrameStyled = styled.div`
+  max-width: 484px;
+`
 
 const Book = ({ data, preview = false }) => {
   const { data: previewData } = usePreviewSubscription(data?.bookPageQuery, {
@@ -83,10 +86,10 @@ const Book = ({ data, preview = false }) => {
                   <Box mb={5}>
                     <Title>{page?.title && page.title}</Title>
                   </Box>
-                  <div
+                  <FrameStyled
                     className="meetings-iframe-container"
                     data-src="https://meetings.hubspot.com/jonna-hjern/intromote-iteam?embed=true"
-                  ></div>
+                  ></FrameStyled>
                 </FormStyled>
               </Col>
               <Col


### PR DESCRIPTION
The book-widget is a bit tricky since the iframe comes with it's own shadow and padding. We could move the left edge of the iframe half the padding or slightly less to take account of the shadow to the left so that the left edge sort of aligns with all text. Or we could center it. None of the approaches really make sense on all pages I'm afraid. Centering would make sense on "book a sprint" though.

---

**current Iteam.se - "book a sprint"**
<img width="1234" alt="Screenshot 2022-04-26 at 12 01 27" src="https://user-images.githubusercontent.com/457653/165275918-1512d9cc-95c0-4575-85e5-36e903b9694f.png">
**After changes - "book a sprint"**
<img width="1234" alt="Screenshot 2022-04-26 at 12 02 11" src="https://user-images.githubusercontent.com/457653/165275940-c71c4128-9bfe-4311-aed3-651eeb4e1fe5.png">
<img width="1234" alt="Screenshot 2022-04-26 at 12 02 17" src="https://user-images.githubusercontent.com/457653/165275951-8d599520-4b4c-481c-b28d-6b3247882a32.png">

---
**current Iteam.se - "/book"**
<img width="1064" alt="Screenshot 2022-04-26 at 12 05 03" src="https://user-images.githubusercontent.com/457653/165276376-6ad0ef1f-fc23-4c9d-b0a2-737e9d5648a8.png">
**After changes - "/book"**
<img width="1064" alt="Screenshot 2022-04-26 at 12 05 12" src="https://user-images.githubusercontent.com/457653/165276391-db97ab0f-ae50-441f-bade-d5dc17c320d1.png">
