### PR TITLE
chore: typography adjustments

### DIFF
--- a/client/src/components/BlockContent/index.js
+++ b/client/src/components/BlockContent/index.js
@@ -37,7 +37,6 @@ const serializers = (withAnchor, variant, color, textAlign, anchorColor) => ({
         case 'subtitle':
           return (
             <Typography.Paragraph
-              variant="small"
               size="subtitle"
               color={color}
               variant="thin"

--- a/client/src/components/ContentCard/index.js
+++ b/client/src/components/ContentCard/index.js
@@ -12,7 +12,7 @@ const StyledBox = styled(Box)`
     dark ? theme.colors.dark : theme.colors.light};
   transition: all 0.3s ease-out;
 
-  h4 {
+  h3 {
     color: ${({ theme, dark }) =>
       dark ? theme.colors.light : theme.colors.dark};
   }

--- a/client/src/components/Core/Title.js
+++ b/client/src/components/Core/Title.js
@@ -3,6 +3,35 @@ import styled from 'styled-components'
 import { color, space, typography, shadow } from 'styled-system'
 import { device } from '../../utils'
 
+const HeroTitle = styled.h1`
+  font-weight: 700;
+  letter-spacing: -2.81px;
+  font-size: 50px;
+  line-height: 56px;
+  margin-bottom: 30px;
+
+  @media ${device.sm} {
+    font-size: 66px;
+    line-height: 70px;
+  }
+
+  @media ${device.lg} {
+    font-size: 76px;
+    line-height: 84px;
+    margin-bottom: 30px;
+  }
+
+  @media ${device.xl} {
+    font-size: 90px;
+    line-height: 94px;
+  }
+
+  ${color};
+  ${space};
+  ${typography};
+  ${shadow};
+`
+
 const SectionTitle = styled.h2`
   font-weight: 700;
   letter-spacing: -2.5px;
@@ -27,29 +56,7 @@ const SectionTitle = styled.h2`
   ${shadow};
 `
 
-const HeroTitle = styled(SectionTitle)`
-  letter-spacing: -2.81px;
-  font-size: 50px;
-  line-height: 56px;
-  margin-bottom: 30px;
-
-  @media ${device.sm} {
-    font-size: 66px;
-    line-height: 70px;
-  }
-
-  @media ${device.lg} {
-    font-size: 76px;
-    line-height: 84px;
-  }
-
-  @media ${device.xl} {
-    font-size: 90px;
-    line-height: 94px;
-  }
-`
-
-const CardTitle = styled.h4`
+const CardTitle = styled.h3`
   font-size: 21px;
   font-weight: 700;
   letter-spacing: -0.66px;

--- a/client/src/components/Typography/index.js
+++ b/client/src/components/Typography/index.js
@@ -7,7 +7,7 @@ const Paragraph = styled.p`
   font-weight: ${({ variant }) => (variant == 'thin' ? 300 : 500)};
   letter-spacing: ${({ variant }) =>
     variant == 'thin' ? 'normal' : '-0.56px'};
-  line-height: ${({ variant }) => (variant == 'thin' ? '38px' : '30px')};
+  line-height: ${({ variant }) => (variant == 'thin' ? '2' : '1.4')};
   text-align: ${({ textAlign }) => (textAlign == 'center' ? 'center' : 'left')};
   color: ${({ color }) =>
     color == 'light' ? 'rgba(255,255,255, 0.7)' : '#19191b'};
@@ -15,14 +15,7 @@ const Paragraph = styled.p`
 const QuoteParagraph = styled(Paragraph)`
   font-size: 19.5px;
 `
-const ParagraphThin = styled.p`
-  margin: 20px 0;
-  font-size: 18px;
-  font-weight: 300;
-  letter-spacing: -0.56px;
-  line-height: 35px;
-  text-align: center;
-`
+
 const H1 = styled.h1`
   font-weight: 700;
   font-size: 50px;
@@ -60,16 +53,16 @@ const H2 = styled.h2`
   line-height: 1.2;
 `
 const H3 = styled.h3`
-  font-size: 28px;
-  margin: 36px 0 20px;
+  font-size: 24px;
+  margin: 2.25rem 0 1.25rem;
   color: black;
   text-align: left;
   font-weight: 500;
   line-height: 1.2;
 `
 const H4 = styled.h4`
-  font-size: 24px;
-  margin: 36px 0 20px;
+  font-size: 20px;
+  margin: 2.25rem 0 1.25rem;
   color: black;
   text-align: left;
   font-weight: 500;
@@ -98,7 +91,6 @@ const BlockQuote = styled.blockquote`
 
 export default {
   Paragraph,
-  ParagraphThin,
   H1,
   H2,
   H3,

--- a/client/src/pages/mvp.js
+++ b/client/src/pages/mvp.js
@@ -53,7 +53,7 @@ const Mvp = ({ data, preview = false }) => {
             }}
           />
         )}
-        <Hero content={mvpPage?.hero && mvpPage.hero} flipTexts={true} />
+        <Hero content={mvpPage?.hero && mvpPage.hero} />
         {mvpPage?.sectionWithButtonAndTextGrid && (
           <SectionWithButtonAndTextGrid
             content={mvpPage.sectionWithButtonAndTextGrid}

--- a/client/src/sections/about/Content.js
+++ b/client/src/sections/about/Content.js
@@ -23,7 +23,7 @@ const Content = ({ content }) => (
       <Container>
         <Row className="justify-content-center pb-4">
           <Col lg="6">
-            <Title variant="hero">{content.section.title}</Title>
+            <Title>{content.section.title}</Title>
           </Col>
           <Col lg="6" className="pl-lg-5">
             <BlockContent blocks={content.section.blockText.blockText} />

--- a/client/src/sections/about/Medarbetare.js
+++ b/client/src/sections/about/Medarbetare.js
@@ -18,6 +18,7 @@ const InfoSection = ({ text, title }) => (
 const Medarbetare = ({ info }) => (
   <Container>
     <Section>
+      <Title className="sr-only">Info</Title>
       <Row className="py-5">
         <Col md={8} lg={6}>
           <Title variant="card">Kontakt</Title>

--- a/client/src/sections/case/CaseList1.js
+++ b/client/src/sections/case/CaseList1.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Row, Col } from 'react-bootstrap'
 
-import { Section } from '../../components/Core'
+import { Section, Title } from '../../components/Core'
 import PostCard from '../../components/PostCard'
 
 const Column = (props) => <Col sm={6} lg={4} className="mb-4" {...props} />
@@ -10,6 +10,7 @@ const CaseList = ({ posts }) => {
     <>
       <Section className="position-relative">
         <Container>
+          <Title className="sr-only">Utvalda case</Title>
           <Row>
             {posts.map((item, i) => {
               return (

--- a/client/src/sections/case/CaseList2.js
+++ b/client/src/sections/case/CaseList2.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Row, Col } from 'react-bootstrap'
 
-import { Section } from '../../components/Core'
+import { Section, Title } from '../../components/Core'
 import CaseCard from '../../components/CaseCard'
 import { urlFor } from '../../utils/helpers'
 
@@ -11,6 +11,7 @@ const CaseList2 = ({ sectionCards }) => {
       {/* <!-- Feature section --> */}
       <Section bg="#F7F7FB" className="position-relative">
         <Container>
+          <Title className="sr-only">Utvalda case</Title>
           <Row className="align-items-center justify-content-center">
             {sectionCards.map((card, i) => {
               return (

--- a/client/src/sections/iteamX/Hero.js
+++ b/client/src/sections/iteamX/Hero.js
@@ -19,14 +19,12 @@ const Hero = ({ content }) => {
         >
           <Row>
             <Col md="11" lg="11" xl="9">
-              <Box
-                py={4}
-              >
-                <Text color="light">{content.subtitle}</Text>
+              <Box py={4}>
                 <Title my={4} variant="hero" color="light">
                   {title}
                   <Span color="secondary">.</Span>
                 </Title>
+                <Text color="light">{content.subtitle}</Text>
                 <Box
                   pt="12px"
                   data-aos="fade-up"

--- a/client/src/sections/karriar/Content.js
+++ b/client/src/sections/karriar/Content.js
@@ -11,7 +11,7 @@ const Content = ({ content, carousel }) => {
         <Container>
           <Row className="justify-content-center pb-4">
             <Col lg="6">
-              <Title variant="hero">{content.title}</Title>
+              <Title>{content.title}</Title>
             </Col>
             <Col lg="6" className="pl-lg-5">
               <BlockContent blocks={content.blockText.blockText} />

--- a/client/src/sections/startpage/Pricing.js
+++ b/client/src/sections/startpage/Pricing.js
@@ -87,7 +87,7 @@ const CardPricing = styled(Box)`
   }
 `
 
-const TitleSmall = styled.h4`
+const TitleSmall = styled.h3`
   color: ${({ theme }) => theme.colors.black};
   font-size: 16px;
   font-weight: 300;
@@ -139,7 +139,6 @@ const Pricing = ({ content }) => {
           <div className="text-center pt-5">
             <div className="d-inline-flex justify-content-between align-items-center mb-5">
               <Text>{content.onGoing}</Text>
-
               <Switch onClick={() => setTimeMonthly(!timeMonthly)} />
               <div className="d-flex align-items-center">
                 <Text>{content.agreement}</Text>
@@ -154,15 +153,16 @@ const Pricing = ({ content }) => {
                     <TitleSmall>{content.team}</TitleSmall>
                     <div className="d-flex align-items-end justify-content-center my-3">
                       <Currency>{content.value}</Currency>
-                      <Title
+                      <Text
                         css={`
-                          font-size: 80px;
+                          font-size: 80px !important;
                           letter-spacing: -1.38px;
-                          margin-bottom: 0 !important;
+                          margin-bottom: 14px !important;
+                          font-weight: 700;
                         `}
                       >
                         {timeMonthly ? content.price : content.priceOngoing}
-                      </Title>
+                      </Text>
                       <TimePer>/h</TimePer>
                     </div>
                     <Text fontSize="18px">{content.priceIncluding}</Text>

--- a/client/src/sections/startpage/TextGrid.js
+++ b/client/src/sections/startpage/TextGrid.js
@@ -27,8 +27,11 @@ const FeatureCard = ({ title, children, ...rest }) => (
 )
 
 const TextGrid = ({ content }) => {
+  console.log(content)
   return (
     <SectionStyled>
+      {/* content.title is actually just a description of the Sanity document type ("Flera texter"), but serves OK as a generic h2 */}
+      <Title className="sr-only">{content.title}</Title>
       <Container>
         <Row className="justify-content-center">
           {content.texts.map((text, i) => {


### PR DESCRIPTION
# Changes

This PR contains different kinds adjustments to typography styling and related element structure on the site. The site now passes lighthouse testing in terms of heading order.

- Adjust existing styling to set a correct hierarchy (h1 -> h2 -> h3 -> h4). 
- Add (hidden) headings where missing.
- Change content order where needed.
- Adjust heading sizes and responsiveness for `BlockContent`

## Content order
Pages `/mvp` and `/iteamX` got their headings moved to the top. This needs to be checked in terms of visibility later on.

### after -> before
<img width="1512" alt="Skärmavbild 2022-05-16 kl  16 23 01" src="https://user-images.githubusercontent.com/51208557/168615382-682d8fb7-07ec-4962-835d-0d35a1c2b76d.png">

### after -> before
<img width="1512" alt="Skärmavbild 2022-05-16 kl  16 23 20" src="https://user-images.githubusercontent.com/51208557/168615413-68f0e9c8-4eaf-4d6e-81b0-e2d3a1fed050.png">

## Article headings
The changes in type size for `BlockContent` headings was partly made to optimize responsiveness, partly to make the hierarchy more clear in an effort to nudge the user towards using correct heading levels, which would improve general accessibility on the site. At the moment there seems to be a habit of using `h3` or `h4` instead of `h2`. _This means content in Sanity should be adjusted in close connection to these changes being merged._

### h2 + h3 before
<img width="1512" alt="Skärmavbild 2022-05-16 kl  16 06 57" src="https://user-images.githubusercontent.com/51208557/168612984-522e653d-c39f-4d8c-b817-06ca933c787c.png">

### h2 + h3 after
<img width="1512" alt="Skärmavbild 2022-05-16 kl  16 06 42" src="https://user-images.githubusercontent.com/51208557/168613068-9cbed34c-dca6-40b8-862f-f4bab3763442.png">

### New h2, h3, h4
<img width="1512" alt="Skärmavbild 2022-05-16 kl  16 44 41" src="https://user-images.githubusercontent.com/51208557/168620042-0bfc5c0f-de0f-47c4-8be9-a349264c6e87.png">

