### PR TITLE
refactor: edit content

### DIFF
--- a/client/src/components/Card/ArticleCard.js
+++ b/client/src/components/Card/ArticleCard.js
@@ -60,12 +60,13 @@ export const ArticleCard = ({
       img={<ArticleCardImage img={img} variant={variant} />}
       preTitle={<ArticleCardPreTitle preTitle={preTitle} />}
       title={title}
-      readMore={true}
       centerContent={false}
       variant={variant}
       bgDark={bgDark}
     >
-      <Typography.ParagraphSmall>{children}</Typography.ParagraphSmall>
+      <Typography.ParagraphSmall className="tw-pb-2">
+        {children}
+      </Typography.ParagraphSmall>
     </BaseCard>
   )
 }

--- a/client/src/components/Card/BaseCard.js
+++ b/client/src/components/Card/BaseCard.js
@@ -58,8 +58,8 @@ export const BaseCard = ({
           <Typography.Caption
             ariaHidden="true"
             className={clsx(
-              'tw-order-4 tw-mb-0 tw-mt-auto tw-px-6 tw-pb-6 tw-pt-1 tw-text-right tw-leading-none tw-underline tw-opacity-0 tw-transition-opacity',
-              'group-hover:tw-opacity-100 peer-focus-within:tw-opacity-100 motion-reduce:tw-transition-none'
+              'tw-order-4 tw-mb-0 tw-mt-auto tw-px-6 tw-pb-6 tw-pt-1 tw-text-right tw-leading-none tw-underline tw-transition-opacity lg:tw-opacity-0',
+              'motion-reduce:tw-transition-none lg:group-hover:tw-opacity-100 lg:peer-focus-within:tw-opacity-100'
             )}
           >
             Läs mer

--- a/client/src/components/Card/BaseCard.js
+++ b/client/src/components/Card/BaseCard.js
@@ -8,7 +8,6 @@ export const BaseCard = ({
   img,
   preTitle,
   title,
-  readMore,
   centerContent,
   children,
   variant,
@@ -46,25 +45,25 @@ export const BaseCard = ({
         {preTitle && (
           <div className="tw-order-2 tw-px-6 tw-pt-6">{preTitle}</div>
         )}
-        <div
-          className={clsx(
-            'tw-order-3 tw-px-6',
-            centerContent && 'tw-text-center'
-          )}
-        >
-          {children}
-        </div>
-        {readMore && (
-          <Typography.Caption
-            ariaHidden="true"
+        {children && (
+          <div
             className={clsx(
-              'tw-order-4 tw-mb-0 tw-mt-auto tw-px-6 tw-pb-6 tw-pt-1 tw-text-right tw-leading-none tw-underline tw-transition-opacity lg:tw-opacity-0',
-              'motion-reduce:tw-transition-none lg:group-hover:tw-opacity-100 lg:peer-focus-within:tw-opacity-100'
+              'tw-order-3 tw-px-6',
+              centerContent && 'tw-text-center'
             )}
           >
-            Läs mer
-          </Typography.Caption>
+            {children}
+          </div>
         )}
+        <Typography.Caption
+          ariaHidden="true"
+          className={clsx(
+            'tw-relative tw-order-4 tw-mb-0 tw-mt-auto tw-px-6 tw-pb-6 tw-pt-1 tw-text-right tw-leading-none tw-underline tw-transition-opacity lg:tw-opacity-0',
+            'motion-reduce:tw-transition-none lg:group-hover:tw-opacity-100 lg:peer-focus-within:tw-opacity-100'
+          )}
+        >
+          Läs mer
+        </Typography.Caption>
       </div>
     </li>
   )

--- a/client/src/components/Card/SimpleCard.js
+++ b/client/src/components/Card/SimpleCard.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import clsx from 'clsx'
 
 import { Typography } from '../Core'
 import { BaseCard } from './BaseCard'
@@ -27,7 +26,6 @@ export const SimpleCard = ({
   preTitle,
   title,
   children,
-  readMore,
   ariaLabel,
   bgDark,
 }) => {
@@ -42,16 +40,13 @@ export const SimpleCard = ({
         />
       }
       title={title}
-      readMore={readMore}
       centerContent={false}
       bgDark={bgDark}
       className="tw-max-w-lg"
     >
-      <Typography.ParagraphSmall
-        className={clsx(readMore ? 'tw-pb-0' : 'tw-pb-6')}
-      >
-        {children}
-      </Typography.ParagraphSmall>
+      {children && (
+        <Typography.ParagraphSmall>{children}</Typography.ParagraphSmall>
+      )}
     </BaseCard>
   )
 }

--- a/client/src/components/Card/TeamCard.js
+++ b/client/src/components/Card/TeamCard.js
@@ -56,7 +56,6 @@ export const TeamCard = ({
         <TeamCardImage img={img} email={email} customImgAlt={customImgAlt} />
       }
       title={title}
-      readMore={false}
       gravatarEmail={email}
       centerContent={true}
       bgDark={bgDark}
@@ -67,7 +66,7 @@ export const TeamCard = ({
         )}
         <Typography.Caption className="tw-pb-3">{role}</Typography.Caption>
       </div>
-      <div className="tw-relative tw-flex tw-flex-col tw-pb-6">
+      <div className="tw-relative tw-flex tw-flex-col tw-pb-2">
         {phoneNumber && (
           <Typography.Caption>
             <Typography.Anchor href={`tel:${phoneNumber}`}>

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -211,7 +211,6 @@ export const Footer = ({ isDark = true, content }) => {
             <Row className="align-items-center">
               <Col
                 sm="6"
-                display="flex"
                 className="text-sm-left text-left mb-2 mb-sm-0 tw-w-full"
               >
                 <p
@@ -220,87 +219,17 @@ export const Footer = ({ isDark = true, content }) => {
                     isDark ? 'tw-text-white' : 'tw-text-gray-dark'
                   )}
                 >
-                  &copy; 2021 Iteam, All Rights Reserved.
-                </p>
-                <p
-                  className={clsx(
-                    'tw-text-xs tw-tracking-normal',
-                    isDark ? 'tw-text-white' : 'tw-text-gray-dark'
-                  )}
-                >
+                  &copy; 2021 Iteam, All Rights Reserved.{' '}
                   <Typography.Anchor
                     className={clsx(
-                      isDark ? 'tw-text-white' : 'tw-text-gray-dark'
+                      isDark ? 'tw-text-white' : 'tw-text-gray-dark',
+                      'tw-underline'
                     )}
                     href="/privacy"
                   >
                     Our privacy policy.
                   </Typography.Anchor>
                 </p>
-              </Col>
-              <Col sm="6" className="tw-w-full">
-                <FooterList className="tw tw-mt-2 tw-flex tw-justify-start tw-gap-3">
-                  <li>
-                    <Typography.Anchor
-                      href={content.linkedinLink}
-                      target="_blank"
-                      aria-label="Linkedin"
-                      className={clsx(
-                        isDark ? 'tw-text-white' : 'tw-text-gray-dark'
-                      )}
-                    >
-                      <i
-                        className="icon icon-logo-linkedin"
-                        aria-hidden="true"
-                      ></i>
-                    </Typography.Anchor>
-                  </li>
-                  <li>
-                    <Typography.Anchor
-                      href={content.twitterLink}
-                      target="_blank"
-                      aria-label="Twitter"
-                      className={clsx(
-                        isDark ? 'tw-text-white' : 'tw-text-gray-dark'
-                      )}
-                    >
-                      <i
-                        className="icon icon-logo-twitter"
-                        aria-hidden="true"
-                      ></i>
-                    </Typography.Anchor>
-                  </li>
-                  <li>
-                    <Typography.Anchor
-                      href={content.facebookLink}
-                      target="_blank"
-                      aria-label="Facebook"
-                      className={clsx(
-                        isDark ? 'tw-text-white' : 'tw-text-gray-dark'
-                      )}
-                    >
-                      <i
-                        className="icon icon-logo-facebook"
-                        aria-hidden="true"
-                      ></i>
-                    </Typography.Anchor>
-                  </li>
-                  <li>
-                    <Typography.Anchor
-                      href={content.instagramLink}
-                      target="_blank"
-                      aria-label="Instagram"
-                      className={clsx(
-                        isDark ? 'tw-text-white' : 'tw-text-gray-dark'
-                      )}
-                    >
-                      <i
-                        className="icon icon-logo-instagram"
-                        aria-hidden="true"
-                      ></i>
-                    </Typography.Anchor>
-                  </li>
-                </FooterList>
               </Col>
             </Row>
           </div>

--- a/client/src/features/Startpage/Offerings.js
+++ b/client/src/features/Startpage/Offerings.js
@@ -92,7 +92,6 @@ export const Offerings = ({ data }) => {
                         link={getRouteNameFromPageType(offer.reference._ref)}
                         icon=""
                         title={offer.title}
-                        readMore={true}
                         bgDark={false}
                       >
                         {offer.subtitle}


### PR DESCRIPTION
# Description
Some changes to site content.
- Removes the second set of SoMe links in footer.
- Adds the "Read more" text on all cards and statically displays this when below tablet screen width.

<img width="1026" alt="Skärmavbild 2022-10-24 kl  11 46 22" src="https://user-images.githubusercontent.com/51208557/197498630-e29f649a-73b7-4a79-8890-4d1e1b658ea7.png">

<img width="373" alt="Skärmavbild 2022-10-24 kl  11 44 35" src="https://user-images.githubusercontent.com/51208557/197498707-0e3011ef-5f16-4825-b4a4-266576f91433.png">

<img width="373" alt="Skärmavbild 2022-10-24 kl  11 44 52" src="https://user-images.githubusercontent.com/51208557/197498709-7737d7c5-e666-4c77-8b69-a6c5391c3a3b.png">

<img width="375" alt="Skärmavbild 2022-10-24 kl  11 45 05" src="https://user-images.githubusercontent.com/51208557/197498710-cab1964f-2972-4d24-afad-6f651e218afe.png">

<img width="372" alt="Skärmavbild 2022-10-24 kl  11 45 20" src="https://user-images.githubusercontent.com/51208557/197498712-5e7121f1-05dc-4ccb-bb4a-22ab7db85cd0.png">
