### PR TITLE
Lägg till Matrix well-known delegation för chat.iteam.se

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,8 +1,24 @@
 const redirects = require('./redirects.json')
-
 module.exports = {
   async redirects() {
     return redirects
+  },
+  async headers() {
+    return [
+      {
+        source: '/.well-known/matrix/server',
+        headers: [
+          { key: 'Content-Type', value: 'application/json' },
+        ],
+      },
+      {
+        source: '/.well-known/matrix/client',
+        headers: [
+          { key: 'Content-Type', value: 'application/json' },
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+        ],
+      },
+    ]
   },
   swcMinify: true,
   compiler: {

--- a/client/public/.well-known/matrix/client
+++ b/client/public/.well-known/matrix/client
@@ -1,0 +1,5 @@
+{
+  "m.homeserver": {
+    "base_url": "https://chat.iteam.se"
+  }
+}

--- a/client/public/.well-known/matrix/server
+++ b/client/public/.well-known/matrix/server
@@ -1,0 +1,3 @@
+{
+     "m.server": "chat.iteam.se:443"
+   }


### PR DESCRIPTION
## Vad
Lägger till två filer under `/.well-known/matrix/` så att iteam.se kan delegera Matrix-trafik till Matrix-server på chat.iteam.se.

## Varför
För att användarna ska få adresser i formatet `@namn:iteam.se` så behöver iteam.se servera två well-known-filer som pekar Matrix-klienter och federerande servrar mot rätt homeserver.

## Vad ändras
- `client/public/.well-known/matrix/server` – talar om för andra Matrix-servrar att de ska prata med `chat.iteam.se:443`
- `client/public/.well-known/matrix/client` – talar om för Matrix-klienter (t.ex. Element) vilken homeserver de ska använda
- `client/next.config.js` – sätter rätt `Content-Type: application/json` på båda filerna samt `Access-Control-Allow-Origin: *` på client-filen (krävs för att Element-webben ska kunna läsa den cross-origin)

## Risk
Mycket låg. Ändringen lägger till nya endpoints på sökvägar som inte används av något annat. Påverkar inte befintliga sidor eller funktionalitet.

## Test efter merge
Efter att Vercel deployat ska följande URL:er returnera JSON:
- https://iteam.se/.well-known/matrix/server
- https://iteam.se/.well-known/matrix/client

Federation kan sedan verifieras på https://federationtester.matrix.org/ med domänen `iteam.se`.