### PR TITLE
Add rtc_foci to Matrix well-known client discovery

### DIFF
--- a/client/public/.well-known/matrix/client
+++ b/client/public/.well-known/matrix/client
@@ -1,5 +1,11 @@
 {
   "m.homeserver": {
     "base_url": "https://chat.iteam.se"
-  }
+  },
+  "org.matrix.msc4143.rtc_foci": [
+    {
+      "type": "livekit",
+      "livekit_service_url": "https://chat.iteam.se/livekit/jwt"
+    }
+  ]
 }


### PR DESCRIPTION
## Vad
Lägger till `org.matrix.msc4143.rtc_foci` i `client/public/.well-known/matrix/client` (den statiska filen som serveras på `/.well-known/matrix/client`).

```json
{
  "m.homeserver": {
    "base_url": "https://chat.iteam.se"
  },
  "org.matrix.msc4143.rtc_foci": [
    {
      "type": "livekit",
      "livekit_service_url": "https://chat.iteam.se/livekit/jwt"
    }
  ]
}
```

## Varför
Utan `rtc_foci` i Matrix client-discovery hittar inte klienterna vår video-backend (LiveKit), och gruppvideosamtal fallerar med `MISSING_MATRIX_RTC_TRANSPORT` — både i Element Web och Element X på mobil. Foci pekar ut LiveKit JWT-servicen (`/livekit/jwt`).

## Detaljer
- `m.homeserver` är oförändrad.
- `livekit_service_url` pekar på JWT-servicen (`/livekit/jwt`), inte `/livekit/sfu`.
- `Content-Type: application/json` och `Access-Control-Allow-Origin: *` sätts oförändrat via `headers()`-regeln i `client/next.config.js`.
- `/.well-known/matrix/server` är orörd.

## Verifiering efter deploy
```
curl -s  https://iteam.se/.well-known/matrix/client   # ska innehålla m.homeserver + org.matrix.msc4143.rtc_foci
curl -sI https://iteam.se/.well-known/matrix/client   # content-type: application/json + access-control-allow-origin: *
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKAgdKmZMFAT3L2C2WhSrZ)_